### PR TITLE
Explicitly import items from `plotting.typ`

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -1,3 +1,3 @@
-#import "/plotst/plotting.typ": *
+#import "/plotst/plotting.typ": plot, overlay, scatter_plot, graph_plot, histogram, pie_chart, bar_chart, compare, class, class_generator, classify
 #import "/plotst/axis.typ": axis
 #import "/plotst/util/classify.typ": class, class_generator, classify


### PR DESCRIPTION
The glob import lead to e.g., `calc.pi` being available as `pi` if a user imports
`plotst` with `import "plotst": *`, very confusing when writing math equations.
