### PR TITLE
New rounding for the step of the axis

### DIFF
--- a/plotst/util/util.typ
+++ b/plotst/util/util.typ
@@ -80,12 +80,12 @@
       if step < 0 {
         while it.last() + step > max {
           assert(it.last() + step < it.last(), message: "step size too small to decrease float")
-          it.push(it.last() + step)
+          it.push(calc.round(it.last() + step, digits: 2))
         }
       } else {
         while it.last() + step < max {
           assert(it.last() + step > it.last(), message: "step size too small to increase float")
-          it.push(it.last() + step)
+          it.push(calc.round(it.last() + step, digits: 2))
         }
       }
       it


### PR DESCRIPTION
# Summary

The current axis system has an issue with floating point precision. For instance, if the step value is set to 0.1, we encounter precision errors where values like 9.99 or 10 are represented inaccurately as floating point values with many decimal places.

# Changes

I have added functionality to round these values to the second decimal place to mitigate this issue. Additionally, I plan to introduce a new parameter in the graph settings that will allow users to specify the desired level of rounding, or disable it altogether if they prefer.

# Screenshots

![image](https://github.com/Pegacraft/typst-plotting/assets/73949405/3b6e4b0d-3542-468c-8644-8db8f57416e7)

# Future Work

Implement a parameter in the graph configuration to allow users to choose the precision for rounding.
Ensure that the rounding functionality is optional and customizable according to user preferences.
